### PR TITLE
Remove pyyaml from install instructions & clarify wrf-python support

### DIFF
--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -195,17 +195,18 @@ WRF NetCDF datasets can be opened under  `QGIS` > `Layers` > `Add Layer` > `Add 
     <img height="300" src="../assets/images/gis4wrf_tab_view.jpg">
     </p>
 
-- Integration with wrf-python
-We currently provide the following additional features using wrf-python:
+#### Experimental integration with wrf-python
+GIS4WRF provides the following additional features when [wrf-python](https://github.com/NCAR/wrf-python) is available:
 
-- Vertical Interpolation of Variables
-- Generation of Derived Variables
+- Vertical interpolation of variables
+- Generation of derived variables
 
-- Vertical Interpolation of Variables
-Currently we offer integration with the vertical interpolation functions provided by wrf-python. Vertical interpolation options can be selected by selecting the variable name and enabling the `Interpolate Vertical Level` check-box.
+!!! warning "Experimental"
+    Due to [lack of Python binary wheels](https://github.com/NCAR/wrf-python/issues/42), wrf-python is not available by default when installing GIS4WRF. No support is provided on how to install wrf-python into the QGIS Python environment.
 
-- Generation of Derived Variables
-The following variables are derived using wrf-python:
+Vertical interpolation options can be chosen by selecting the variable name and enabling the `Interpolate Vertical Level` check-box.
+
+The following derived variables are generated using wrf-python:
 
 |Variable Name | Description |
 |--------|------|

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -25,7 +25,7 @@ You need to have [Homebrew](https://brew.sh/) installed on your system. Then, si
 brew tap osgeo/osgeo4mac &&
 brew install qgis3 && brew install qgis3 && # avoid issues with current formula
 brew install gcc mpich python hdf5 netcdf &&
-pip3 install --user f90nml pyyaml netCDF4 wrf-python
+pip3 install --user f90nml netCDF4
 ```
 
 You can now launch QGIS 3 from your Terminal prompt with the `qgis3` command. To install GIS4WRF, go to [Install GIS4WRF](#install-gis4wrf).
@@ -46,7 +46,7 @@ sudo add-apt-repository -s 'deb https://qgis.org/debian artful main' &&
 sudo apt-get update &&
 sudo apt-get install -y qgis python-qgis gfortran mpich &&
 sudo apt-get install -y python3-pip &&
-pip3 install --user f90nml pyyaml netCDF4 wrf-python
+pip3 install --user f90nml netCDF4
 ```
 
 After you have successfully installed QGIS 3, go to [Install GIS4WRF](#install-gis4wrf).
@@ -64,7 +64,7 @@ sudo add-apt-repository -s 'deb https://qgis.org/debian bionic main' &&
 sudo apt-get update &&
 sudo apt-get install -y qgis python-qgis gfortran mpich &&
 sudo apt-get install -y python3-pip &&
-pip3 install --user f90nml pyyaml netCDF4 wrf-python
+pip3 install --user f90nml netCDF4
 ```
 After you have successfully installed QGIS 3, go to [Install GIS4WRF](#install-gis4wrf).
 


### PR DESCRIPTION
To be merged once GIS4WRF 0.14.5 is released (as the new version removes the pyyaml dependency).